### PR TITLE
Add fakeredis as optional import

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ async def test_redis(my_app):
         result = await client.get("/")
         assert await result.data == b"it works!"
 ```
+
+## Faking Redis
+
+For development and testing, you may not have a running Redis instance. In this case, the [`fakeredis`](https://pypi.org/project/fakeredis/) package may be installed and then used instead of actual redis by setting `USE_FAKE_REDIS` environment variable to true at runtime.

--- a/quart_redis/__init__.py
+++ b/quart_redis/__init__.py
@@ -1,9 +1,16 @@
 import asyncio
 import logging
 from typing import Optional
+from os import getenv
 
 from quart import Quart
-from redis.asyncio import Redis, RedisError, from_url
+
+if os.getenv('USE_FAKE_REDIS', 'false').lower() == 'true':
+    from fakeredis.aioredis import FakeRedis as Redis
+    from fakeredis.aioredis import FakeRedisError as RedisError
+    from fakeredis.aioredis import from_url
+else:
+    from redis.asyncio import Redis, RedisError, from_url
 
 __all__ = ["RedisHandler", "get_redis"]
 __version__ = "2.0.0"


### PR DESCRIPTION
fakeredis ( https://pypi.org/project/fakeredis/ ) is a library that allows development and testing of Redis dependent software without a Redis instance by faking many of the Redis client calls.

This patch provides the ability to use fakeredis in place of normal Redis if fakeredis is installed and the `USE_FAKE_REDIS` environment variable is set at runtime.

